### PR TITLE
Use of getpixelposition speeds up plotboxpos.m significantly.

### DIFF
--- a/plotboxpos/plotboxpos.m
+++ b/plotboxpos/plotboxpos.m
@@ -32,9 +32,7 @@ end
 % Get position of axis in pixels
 
 currunit = get(h, 'units');
-set(h, 'units', 'pixels');
-axisPos = get(h, 'Position');
-set(h, 'Units', currunit);
+axisPos  = getpixelposition(h);
 
 % Calculate box position based axis limits and aspect ratios
 


### PR DESCRIPTION
Also fixes problem with some Windows(?) Matlab releases:
https://github.com/kakearney/plotboxpos-pkg/issues/4